### PR TITLE
Write tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *~
 .DS_Store
 .*
+*.fits
+*.pdf
+*.png

--- a/newdust/graindist/graindist.py
+++ b/newdust/graindist/graindist.py
@@ -16,10 +16,18 @@ __all__ = ['GrainDist']
 class GrainDist(object):
     """
     | **ATTRIBUTES**
-    | size  : Abstract class from astrodust.sizedist
-    | comp  : Abstract class from astrodust.composition
-    | shape : Abstract class from astrodust.shape
+    | size  : Abstract class from newdust.sizedist
+    | comp  : Abstract class from newdust.composition
+    | shape : Abstract class from newdust.shape
     | md    : float
+    | a     : grain radii from size.a
+    | ndens : number density from size.ndens using the other attributes as input
+    | mdens : mass density as a function of grain size
+    | cgeo  : physical cross-sectional area based on grain shape
+    | vol   : physical grain volume based on grain shape
+    |
+    | *methods*
+    | plot(ax, kwargs) : Plots the number density of dust grains via size.plot()
     |
     | **__init__**
     | dtype   : 'Grain', 'Powerlaw' or 'ExpCutoff' (defines the grain size distribution)
@@ -35,15 +43,6 @@ class GrainDist(object):
     |   if True, will set attributes of size, comp, and shape with raw input values
     | **kwargs : extra input to the size dist functions
     |
-    | *properties*
-    | a     : grain radii from size.a
-    | ndens : number density from size.ndens using the other attributes as input
-    | mdens : mass density as a function of grain size
-    | cgeo  : physical cross-sectional area based on grain shape
-    | vol   : physical grain volume based on grain shape
-    |
-    | *functions*
-    | plot(ax, kwargs) : Plots the number density of dust grains via size.plot()
     """
     def __init__(self, dtype, cmtype, shape='Sphere', md=MD_DEFAULT,
                  amax=AMAX, rho=None, custom=False, **kwargs):

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.integrate import trapz
+from astropy.io import fits
 
 from . import graindist
 from . import scatmodels
@@ -124,6 +125,31 @@ class SingleGrainPop(graindist.GrainDist):
         print("Extinction calculated with: %s" % self.scatm.stype)
         print("Grain composition: %s" % self.comp.cmtype)
         print("rho = %.2f g cm^-3, M_d = %.2e g cm^-2" % (self.rho, self.md))
+
+    # Write an extinction table
+    def write_extinction_table(self, outfile):
+        ff = open(outfile, 'w')
+        ff.write("This is extinction table output")
+        ff.close()
+        return
+
+    # writes an extinction table header
+    def __write_extinction_table_header(self):
+        return
+
+    # writes table parameters
+    def __write_extinction_table_pars(self):
+        # e.g. pars['lam'], pars['a']
+        # should this be part of WCS?
+        return
+
+    # writes table data
+    def __write_extinction_table_data(self):
+        # e.g. 2D array of sigma(a, E)
+        cgeo    = c._make_array(self.cgeo)    # cm**2
+        geo_2d  = np.repeat(cgeo.reshape(1, NA), NE, axis=0)  # NE x NA
+        sigma_ext = self.scatm.qext * geo_2d  # cm**2
+        return
 
 class GrainPop(object):
     """

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -18,17 +18,10 @@ ALLOWED_SCATM = ['RG','Mie']
 # Make this a subclass of GrainDist at some point
 class SingleGrainPop(graindist.GrainDist):
     """
-    | A single dust grain population. Can add a string describing the Grain population using the *description* keyword
-    |
     | **ATTRIBUTES**
-    | description : a string describing the grain population
-    | gdist : GrainDist object
-    | stype : string : Scattering model to use
-    |
-    | *The following attributes are inherited form the GrainDist object*
+    | lam, lam_unit, tau_ext, tau_sca, tau_abs, diff, int_diff
+    | *Inherited from the GrainDist object*
     | a, ndens, mdens, cgeo, vol
-    | *The following attributes are inherited from the Extinction object*
-    | lam, lam_unit, tau_ext, tau_sca, tau_abs
     |
     | *functions*
     | calculate_ext(lam, unit='kev', **kwargs) runs the extinction calculation on the wavelength grid specified by lam and unit
@@ -36,6 +29,8 @@ class SingleGrainPop(graindist.GrainDist):
     | plot_ext(ax, keyword, **kwargs) plots the extinction properties (see *astrodust.extinction*)
     |   - ``keyword`` options are "ext", "sca", "abs", "all"
     | info() prints information about the dust grain properties
+    | write_extinction_table(outfile, **kwargs) writes extinction table
+    |    (qext, qabs, qsca, and diff-xsect) for the calculated scattering properties
     """
     def __init__(self, dtype, cmtype, stype, shape='Sphere', md=MD_DEFAULT, **kwargs):
         graindist.GrainDist.__init__(self, dtype, cmtype, shape=shape, md=md, **kwargs)
@@ -120,35 +115,14 @@ class SingleGrainPop(graindist.GrainDist):
 
     # Printing information
     def info(self):
-        print("Grain Population: %s" % self.description)
         print("Size distribution: %s" % self.size.dtype)
         print("Extinction calculated with: %s" % self.scatm.stype)
         print("Grain composition: %s" % self.comp.cmtype)
         print("rho = %.2f g cm^-3, M_d = %.2e g cm^-2" % (self.rho, self.md))
 
     # Write an extinction table
-    def write_extinction_table(self, outfile):
-        ff = open(outfile, 'w')
-        ff.write("This is extinction table output")
-        ff.close()
-        return
-
-    # writes an extinction table header
-    def __write_extinction_table_header(self):
-        return
-
-    # writes table parameters
-    def __write_extinction_table_pars(self):
-        # e.g. pars['lam'], pars['a']
-        # should this be part of WCS?
-        return
-
-    # writes table data
-    def __write_extinction_table_data(self):
-        # e.g. 2D array of sigma(a, E)
-        cgeo    = c._make_array(self.cgeo)    # cm**2
-        geo_2d  = np.repeat(cgeo.reshape(1, NA), NE, axis=0)  # NE x NA
-        sigma_ext = self.scatm.qext * geo_2d  # cm**2
+    def write_extinction_table(self, outfile, **kwargs):
+        self.scatm.write_table(outfile, **kwargs)
         return
 
 class GrainPop(object):

--- a/newdust/scatmodels/__init__.py
+++ b/newdust/scatmodels/__init__.py
@@ -4,33 +4,20 @@ from .. import constants as c
 
 """
 --------------------------------------------------------------
-    API
+    API for Abstract Class 'ScatModel'
 --------------------------------------------------------------
- A dust scattering model should contain functions that take
- energy value, complex index of refraction object (see cmlib),
- and grain sizes
+ A dust scattering model should contain the following attributes
 
- Qsca ( E  : scalar or np.array [keV]
-        cm : cmtype object from cmi.py
-        a  : scalar [grain size, micron] ) :
- returns scalar or np.array [scattering efficiency, unitless]
+calculate( lam : scalar or np.array [wavelength or energy grid, keV default]
+           a   : scalar [grain size, micron]
+           cm  : newdust.graindist.composition cm object (abstract class)
+           unit = : string ['kev', 'angs']
+           theta = : scalar or np.array [angles to calculate differential scattering, arcsec, default 0.0]
+           **kwargs
+           )
 
- Diff ( cm : cmtype object from cmi.py
-        theta : scalar or np.array [angle, arcsec]
-        a  : scalar [grain size, micron]
-        E  : scalar or np.array [energy, keV]
-        ** if len(E) > 1 and len(theta) > 1, then len(E) must equal len(theta)
-           returns dsigma/dOmega of values (E0,theta0), (E1,theta1) etc...
-
- Some (but not all) scattering models may also contain related extinction terms
-
- Qext ( E  : scalar or np.array [keV]
-        cm : cmtype object cmi.py
-        a  : scalar [grain size, micron] ) :
- returns scalar or np.array [extinction efficiency, unitless]
-
- Qabs ( E  : scalar or np.array [keV]
-        cm : cmtype object cmi.py
-        a  : scalar [grain size, micron] ) :
- returns scalar or np.array [absorption efficiency, unitless]
+qsca : np.array, scattering efficiency [unitless]
+qabs : np.array, absorption efficiency [unitless]
+qext : np.array, extinction efficiency [unitless]
+self.diff : np.array, differentifal scattering cross section [cm**2/ster]
 """

--- a/newdust/scatmodels/__init__.py
+++ b/newdust/scatmodels/__init__.py
@@ -19,5 +19,9 @@ calculate( lam : scalar or np.array [wavelength or energy grid, keV default]
 qsca : np.array, scattering efficiency [unitless]
 qabs : np.array, absorption efficiency [unitless]
 qext : np.array, extinction efficiency [unitless]
-self.diff : np.array, differentifal scattering cross section [cm**2/ster]
+diff : np.array, differentifal scattering cross section [cm**2/ster]
+pars : dict, stores the parameters used to run `calculate`
+
+write_table( outfile : string [filename for writing a FITS table of efficiency values]
+            )
 """

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -60,7 +60,7 @@ class Mie(ScatModel):
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0, memlim=MAX_RAM):
 
-        self.pars = dict(zip(['lam','a','cm','theta','lam_unit'],[lam, a, cm, theta, unit]))
+        self.pars = dict(zip(['lam','a','cm','theta','unit'],[lam, a, cm, theta, unit]))
 
         NE, NA, NTH = np.size(lam), np.size(a), np.size(theta)
 

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -45,9 +45,9 @@ class Mie(object):
         self.pars  = None  # parameters used in running the calculation: lam, a, cm, theta, unit
         self.qsca  = None
         self.qext  = None
-        self.qback = None
-        self.gsca  = None
         self.diff  = None
+        self.gsca  = None
+        self.qback = None
 
     @property
     def qabs(self):

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -1,5 +1,6 @@
 import numpy as np
 from .. import constants as c
+from .scatmodel import _ScatModel
 
 __all__ = ['Mie']
 
@@ -14,7 +15,7 @@ MAX_RAM = 8.0
 #    to calculate scattering and absorption by a homogenous isotropic
 #    sphere.''
 #
-class Mie(object):
+class Mie(_ScatModel):
     """
     | Mie scattering algorithms of Bohren & Hoffman
     | See their book: *Absorption and Scattering of Light by Small Particles*
@@ -86,11 +87,11 @@ class Mie(object):
         geo    = np.pi * a_cm**2  # NE x NA
         geo_3d = np.repeat(geo.reshape(NE, NA, 1), NTH, axis=2)
 
-        self.qsca  = qsca
+        self.qsca  = qsca  # NE x NA
         self.qext  = qext
         self.qback = qback
         self.gsca  = gsca
-        self.diff  = Cdiff * geo_3d  # cm^2 / ster
+        self.diff  = Cdiff * geo_3d  # cm^2 / ster,  NE x NA x NTH
 
 #---------------- Helper function that does the actual calculation
 

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .. import constants as c
-from .scatmodel import _ScatModel
+from .scatmodel import ScatModel
 
 __all__ = ['Mie']
 
@@ -15,7 +15,7 @@ MAX_RAM = 8.0
 #    to calculate scattering and absorption by a homogenous isotropic
 #    sphere.''
 #
-class Mie(_ScatModel):
+class Mie(ScatModel):
     """
     | Mie scattering algorithms of Bohren & Hoffman
     | See their book: *Absorption and Scattering of Light by Small Particles*

--- a/newdust/scatmodels/rgscat.py
+++ b/newdust/scatmodels/rgscat.py
@@ -1,11 +1,12 @@
 import numpy as np
 from .. import constants as c
+from .scatmodel import _ScatModel
 
 __all__ = ['RGscat']
 
 CHARSIG       = 1.04 * 60.0  # characteristic scattering angle [arcsec E(keV)^-1 a(um)^-1]
 
-class RGscat(object):
+class RGscat(_ScatModel):
     """
     | RAYLEIGH-GANS scattering model.
     | *see* Mauche & Gorenstein (1986), ApJ 302, 371

--- a/newdust/scatmodels/rgscat.py
+++ b/newdust/scatmodels/rgscat.py
@@ -43,7 +43,7 @@ class RGscat(ScatModel):
         return self.qext - self.qsca
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0):
-        self.pars = dict(zip(['lam','a','cm','theta','lam_unit'],[lam, a, cm, theta, unit]))
+        self.pars = dict(zip(['lam','a','cm','theta','unit'],[lam, a, cm, theta, unit]))
 
         NE, NA, NTH = np.size(lam), np.size(a), np.size(theta)
 

--- a/newdust/scatmodels/rgscat.py
+++ b/newdust/scatmodels/rgscat.py
@@ -1,12 +1,12 @@
 import numpy as np
 from .. import constants as c
-from .scatmodel import _ScatModel
+from .scatmodel import ScatModel
 
 __all__ = ['RGscat']
 
 CHARSIG       = 1.04 * 60.0  # characteristic scattering angle [arcsec E(keV)^-1 a(um)^-1]
 
-class RGscat(_ScatModel):
+class RGscat(ScatModel):
     """
     | RAYLEIGH-GANS scattering model.
     | *see* Mauche & Gorenstein (1986), ApJ 302, 371

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -2,7 +2,7 @@ from astropy.io import fits
 
 ## Superclass _ScatModel
 ## See __init__ for API
-class _ScatModel(object):
+class ScatModel(object):
     def __init__(self):
         self.qsca = None
         self.qext = None

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -1,0 +1,33 @@
+from astropy.io import fits
+
+## Superclass _ScatModel
+## See __init__ for API
+class _ScatModel(object):
+    def __init__(self):
+        self.qsca = None
+        self.qext = None
+        self.qabs = None
+        self.diff = None
+        self.pars = None
+
+    def calculate(self, lam, a, cm, unit='kev', theta=0.0, **kwargs):
+        print("You are attempting to run calculation from _ScatModel superclass.")
+        print("No attributes will be updated.")
+        return
+
+    def write_efficiency_table(self, outfile):
+        hdr = self.__write_table_header()
+        pardata = self.__write_table_pars(self, ['lam','a'])
+        # self.qsca, self.qext, and self.qabs will be separate cards in the FITS file
+        return
+
+    ##----- Helper material
+    def __write_table_header(self):
+        """ Writes FITS file header based on self.pars """
+        return
+
+    def __write_table_pars(self, parlist):
+        """writes table parameters from self.pars"""
+        # e.g. pars['lam'], pars['a']
+        # should this be part of WCS?
+        return

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -18,18 +18,25 @@ class ScatModel(object):
         return
 
     def write_efficiency_table(self, outfile, overwrite=True):
+        # some basic info
         header    = self._write_table_header()
+        # wavelength (or energy) and grain radius associated with calculation
         par_table = self._write_table_pars()
-        # self.qsca, self.qext, and self.qabs will be separate cards in the FITS file
-        #hdu_list = fits.HDUList([fits.PrimaryHDU(q) for q in [self.qext, self.qabs, self.qsca]])
-        hdu_list = fits.HDUList(hdus=[fits.PrimaryHDU(self.qext), fits.ImageHDU(self.qsca)])
+        # qext, qsca, and qext will be separate image cards in the FITS file
+        img_list  = [fits.ImageHDU(q) for q in [self.qext, self.qabs, self.qsca]]
+        # Put everything together to write the table
+        fnl_list  = [header, par_table] + img_list
+        hdu_list  = fits.HDUList(hdus=fnl_list)
         hdu_list.writeto(outfile, overwrite=overwrite)
         return
 
     ##----- Helper material
     def _write_table_header(self):
         """ Writes FITS file header based on self.pars """
-        return
+        result = fits.Header()
+        result['COMMENT']  = "Extinction efficiency table"
+        result['COMMENT']  = "Qext, Qsca, Qabs in wavelength (or energy) vs grain radius"
+        return fits.PrimaryHDU(header=result)
 
     def _write_table_pars(self):
         """writes table lam and a parameters from self.pars"""

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -15,10 +15,13 @@ class _ScatModel(object):
         print("No attributes will be updated.")
         return
 
-    def write_efficiency_table(self, outfile):
+    def write_efficiency_table(self, outfile, overwrite=True):
         hdr = self.__write_table_header()
-        pardata = self.__write_table_pars(self, ['lam','a'])
+        pardata = self.__write_table_pars(['lam','a'])
         # self.qsca, self.qext, and self.qabs will be separate cards in the FITS file
+        #hdu_list = fits.HDUList([fits.PrimaryHDU(q) for q in [self.qext, self.qabs, self.qsca]])
+        hdu_list = fits.HDUList([fits.PrimaryHDU(self.qext)])
+        hdu_list.writeto(outfile, overwrite=overwrite)
         return
 
     ##----- Helper material

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -25,7 +25,7 @@ class ScatModel(object):
         # qext, qsca, and qext will be separate image cards in the FITS file
         img_list = []
         for (q, h) in zip([self.qext, self.qabs, self.qsca, self.diff],
-                          ['Qext', 'Qabs', 'Qsca', 'Diff (cm^2/ster)']):
+                          ['Qext', 'Qabs', 'Qsca', 'Diff-xsect (cm^2/ster)']):
             htemp = fits.Header()
             htemp['TYPE'] = h
             img_list.append(fits.ImageHDU(self.qext, header=htemp))
@@ -39,8 +39,9 @@ class ScatModel(object):
     def _write_table_header(self):
         """ Writes FITS file header based on self.pars """
         result = fits.Header()
-        result['COMMENT']  = "Extinction efficiency table"
-        result['COMMENT']  = "Qext, Qsca, Qabs in wavelength (or energy) vs grain radius"
+        result['COMMENT']  = "Extinction efficiency and differential cross-sections"
+        result['COMMENT']  = "HDUS 4-6 are Qext, Qsca, Qabs in wavelength (or energy) vs grain radius"
+        result['COMMENT']  = "HDU 7 is differential cross-section (cm^2/ster)"
         return fits.PrimaryHDU(header=result)
 
     def _write_table_pars(self):

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -51,4 +51,4 @@ class ScatModel(object):
         c3 = fits.BinTableHDU.from_columns(
              [fits.Column(name='theta', array=c._make_array(self.pars['theta']),
              format='E', unit='arcsec')])
-        return [c1, c2]
+        return [c1, c2, c3]

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -17,13 +17,18 @@ class ScatModel(object):
         self.pars = {'lam':lam, 'a':a, 'cm':cm, 'unit':unit, 'theta':theta}
         return
 
-    def write_efficiency_table(self, outfile, overwrite=True):
+    def write_table(self, outfile, overwrite=True):
         # some basic info
         header    = self._write_table_header()
         # wavelength (or energy) and grain radius associated with calculation
         par_table = self._write_table_pars()
         # qext, qsca, and qext will be separate image cards in the FITS file
-        img_list  = [fits.ImageHDU(q) for q in [self.qext, self.qabs, self.qsca, self.diff]]
+        img_list = []
+        for (q, h) in zip([self.qext, self.qabs, self.qsca, self.diff],
+                          ['Qext', 'Qabs', 'Qsca', 'Diff (cm^2/ster)']):
+            htemp = fits.Header()
+            htemp['TYPE'] = h
+            img_list.append(fits.ImageHDU(self.qext, header=htemp))
         # Put everything together to write the table
         fnl_list  = [header] + par_table + img_list
         hdu_list  = fits.HDUList(hdus=fnl_list)

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -20,7 +20,7 @@ class ScatModel(object):
         pardata = self.__write_table_pars(['lam','a'])
         # self.qsca, self.qext, and self.qabs will be separate cards in the FITS file
         #hdu_list = fits.HDUList([fits.PrimaryHDU(q) for q in [self.qext, self.qabs, self.qsca]])
-        hdu_list = fits.HDUList([fits.PrimaryHDU(self.qext)])
+        hdu_list = fits.HDUList(hdus=[fits.PrimaryHDU(self.qext), fits.ImageHDU(self.qsca)])
         hdu_list.writeto(outfile, overwrite=overwrite)
         return
 

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -1,4 +1,5 @@
 from astropy.io import fits
+from .. import constants as c
 
 ## Superclass _ScatModel
 ## See __init__ for API
@@ -11,13 +12,14 @@ class ScatModel(object):
         self.pars = None
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0, **kwargs):
-        print("You are attempting to run calculation from _ScatModel superclass.")
+        print("You are attempting to run calculation from ScatModel superclass.")
         print("No attributes will be updated.")
+        self.pars = {'lam':lam, 'a':a, 'cm':cm, 'unit':unit, 'theta':theta}
         return
 
     def write_efficiency_table(self, outfile, overwrite=True):
-        hdr = self.__write_table_header()
-        pardata = self.__write_table_pars(['lam','a'])
+        header    = self._write_table_header()
+        par_table = self._write_table_pars()
         # self.qsca, self.qext, and self.qabs will be separate cards in the FITS file
         #hdu_list = fits.HDUList([fits.PrimaryHDU(q) for q in [self.qext, self.qabs, self.qsca]])
         hdu_list = fits.HDUList(hdus=[fits.PrimaryHDU(self.qext), fits.ImageHDU(self.qsca)])
@@ -25,12 +27,14 @@ class ScatModel(object):
         return
 
     ##----- Helper material
-    def __write_table_header(self):
+    def _write_table_header(self):
         """ Writes FITS file header based on self.pars """
         return
 
-    def __write_table_pars(self, parlist):
-        """writes table parameters from self.pars"""
+    def _write_table_pars(self):
+        """writes table lam and a parameters from self.pars"""
         # e.g. pars['lam'], pars['a']
         # should this be part of WCS?
-        return
+        c1 = fits.Column(name='lam', array=c._make_array(self.pars['lam']), format='E', unit=self.pars['unit'])
+        c2 = fits.Column(name='a', array=c._make_array(self.pars['a']), format='E', unit='micron')
+        return fits.BinTableHDU.from_columns([c1, c2])

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -25,7 +25,7 @@ class ScatModel(object):
         # qext, qsca, and qext will be separate image cards in the FITS file
         img_list  = [fits.ImageHDU(q) for q in [self.qext, self.qabs, self.qsca]]
         # Put everything together to write the table
-        fnl_list  = [header, par_table] + img_list
+        fnl_list  = [header] + par_table + img_list
         hdu_list  = fits.HDUList(hdus=fnl_list)
         hdu_list.writeto(outfile, overwrite=overwrite)
         return
@@ -42,6 +42,10 @@ class ScatModel(object):
         """writes table lam and a parameters from self.pars"""
         # e.g. pars['lam'], pars['a']
         # should this be part of WCS?
-        c1 = fits.Column(name='lam', array=c._make_array(self.pars['lam']), format='E', unit=self.pars['unit'])
-        c2 = fits.Column(name='a', array=c._make_array(self.pars['a']), format='E', unit='micron')
-        return fits.BinTableHDU.from_columns([c1, c2])
+        c1 = fits.BinTableHDU.from_columns(
+             [fits.Column(name='lam', array=c._make_array(self.pars['lam']),
+             format='E', unit=self.pars['unit'])])
+        c2 = fits.BinTableHDU.from_columns(
+             [fits.Column(name='a', array=c._make_array(self.pars['a']),
+             format='E', unit='micron')])
+        return [c1, c2]

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -23,7 +23,7 @@ class ScatModel(object):
         # wavelength (or energy) and grain radius associated with calculation
         par_table = self._write_table_pars()
         # qext, qsca, and qext will be separate image cards in the FITS file
-        img_list  = [fits.ImageHDU(q) for q in [self.qext, self.qabs, self.qsca]]
+        img_list  = [fits.ImageHDU(q) for q in [self.qext, self.qabs, self.qsca, self.diff]]
         # Put everything together to write the table
         fnl_list  = [header] + par_table + img_list
         hdu_list  = fits.HDUList(hdus=fnl_list)
@@ -48,4 +48,7 @@ class ScatModel(object):
         c2 = fits.BinTableHDU.from_columns(
              [fits.Column(name='a', array=c._make_array(self.pars['a']),
              format='E', unit='micron')])
+        c3 = fits.BinTableHDU.from_columns(
+             [fits.Column(name='theta', array=c._make_array(self.pars['theta']),
+             format='E', unit='arcsec')])
         return [c1, c2]

--- a/tests/test_grainpop.py
+++ b/tests/test_grainpop.py
@@ -96,6 +96,8 @@ def test_ext_calculations(sd, cm, sc):
     assert np.shape(test.tau_abs) == (NE,)
     assert np.shape(test.diff) == (NE, len(test.a), NTH)
     assert all(percent_diff(test.tau_ext, test.tau_abs + test.tau_sca) <= 0.01)
+    test.info()
+    test.write_extinction_table('test_grainpop.fits')
 
 # Make sure that doubling the dust mass doubles the extinction
 @pytest.mark.parametrize('estring', ALLOWED_SCATM)

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -60,7 +60,7 @@ def test_rgscat():
     assert test.diff == 0.0
 
     # Test the write function
-    test.write_efficiency_table('qrg.fits')
+    test.write_table('qrg.fits')
 
 @pytest.mark.parametrize('cm',
                          [composition.CmDrude(),
@@ -83,7 +83,7 @@ def test_mie(cm):
     assert percent_diff(dtot, sigsca) <= 0.01
 
     # Test the write function
-    test.write_efficiency_table('qmie.fits')
+    test.write_table('qmie.fits')
 
 @pytest.mark.parametrize('sm',
                          [scatmodels.RGscat(),
@@ -112,4 +112,4 @@ from newdust.scatmodels.scatmodel import ScatModel
 #                          scatmodels.Mie()])
 def test_writing(sm):
     sm.calculate(0.0, 0.0, 0.0)
-    sm.write_efficiency_table('test_scatmodels.fits')
+    sm.write_table('test_scatmodels.fits')

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -99,9 +99,10 @@ def test_dimensions(sm):
     assert percent_diff(dtot1, ssca1) <= 0.05
     assert percent_diff(dtot2, ssca2) <= 0.05
 
+from newdust.scatmodels.scatmodel import ScatModel
 # Test the writing and reading functions
-@pytest.mark.parametrize('sm',
-                         [scatmodels.RGscat(),
-                          scatmodels.Mie()])
+@pytest.mark.parametrize('sm', [ScatModel()])
+#                         [scatmodels.RGscat(),
+#                          scatmodels.Mie()])
 def test_writing(sm):
     sm.write_efficiency_table('test_scatmodels.fits')

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -105,4 +105,5 @@ from newdust.scatmodels.scatmodel import ScatModel
 #                         [scatmodels.RGscat(),
 #                          scatmodels.Mie()])
 def test_writing(sm):
+    sm.calculate(0.0, 0.0, 0.0)
     sm.write_efficiency_table('test_scatmodels.fits')

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -59,6 +59,9 @@ def test_rgscat():
     test.calculate(E_KEV, A_UM, CMD, unit='kev', theta=1.e10)
     assert test.diff == 0.0
 
+    # Test the write function
+    test.write_efficiency_table('qrg.fits')
+
 @pytest.mark.parametrize('cm',
                          [composition.CmDrude(),
                           composition.CmSilicate(),
@@ -78,6 +81,9 @@ def test_mie(cm):
     dtot = trapz(test.diff * 2.0*np.pi*np.sin(THETA), THETA)  # cm^2
     sigsca = test.qsca * np.pi * (A_UM * c.micron2cm)**2  # cm^2
     assert percent_diff(dtot, sigsca) <= 0.01
+
+    # Test the write function
+    test.write_efficiency_table('qmie.fits')
 
 @pytest.mark.parametrize('sm',
                          [scatmodels.RGscat(),

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -98,3 +98,10 @@ def test_dimensions(sm):
     ssca2 = sm.qsca[-1,-1] * np.pi * (AVALS[-1] * 1.e-4)**2
     assert percent_diff(dtot1, ssca1) <= 0.05
     assert percent_diff(dtot2, ssca2) <= 0.05
+
+# Test the writing and reading functions
+@pytest.mark.parametrize('sm',
+                         [scatmodels.RGscat(),
+                          scatmodels.Mie()])
+def test_writing(sm):
+    sm.write_efficiency_table('test_scatmodels.fits')


### PR DESCRIPTION
Rudimentary table writing methods implemented:

* `ScatModel.write_table(outfile, overwrite=)`
* `SingleGrainPop.write_extinction_table(outfile, **kwargs)` invokes *ScatModel.write_table*
* *Mie* and *RGscat* are now sub-classes of *ScatModel*