### PR TITLE
Custom models

### DIFF
--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -13,7 +13,7 @@ AMIN, AMAX, P = 0.005, 0.3, 3.5  # um, um, unitless
 RHO_AVG       = 3.0  # g cm^-3
 UNIT_LABELS   = {'kev':'Energy (keV)', 'angs':'Wavelength (angs)'}
 
-ALLOWED_SCATM = ['RG','Mie']
+SCATMODELS = {'RG':scatmodels.RGscat(),'Mie':scatmodels.Mie()}
 
 # Make this a subclass of GrainDist at some point
 class SingleGrainPop(graindist.GrainDist):
@@ -32,13 +32,14 @@ class SingleGrainPop(graindist.GrainDist):
     | write_extinction_table(outfile, **kwargs) writes extinction table
     |    (qext, qabs, qsca, and diff-xsect) for the calculated scattering properties
     """
-    def __init__(self, dtype, cmtype, stype, shape='Sphere', md=MD_DEFAULT, **kwargs):
-        graindist.GrainDist.__init__(self, dtype, cmtype, shape=shape, md=md, **kwargs)
-        assert stype in ALLOWED_SCATM
-        if stype == 'RG':
-            self.scatm = scatmodels.RGscat()
-        if stype == 'Mie':
-            self.scatm = scatmodels.Mie()
+    def __init__(self, dtype, cmtype, stype, shape='Sphere', md=MD_DEFAULT, custom=False, **kwargs):
+        graindist.GrainDist.__init__(self, dtype, cmtype, shape=shape, md=md, custom=custom, **kwargs)
+        if custom:
+            if isinstance(stype, str): pass
+            else: self.scatm = stype
+        else:
+            assert stype in SCATMODELS.keys()
+            self.scatm = SCATMODELS[stype]
 
         self.lam      = None  # NE
         self.lam_unit = None  # string

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -34,12 +34,11 @@ class SingleGrainPop(graindist.GrainDist):
     """
     def __init__(self, dtype, cmtype, stype, shape='Sphere', md=MD_DEFAULT, custom=False, **kwargs):
         graindist.GrainDist.__init__(self, dtype, cmtype, shape=shape, md=md, custom=custom, **kwargs)
-        if custom:
-            if isinstance(stype, str): pass
-            else: self.scatm = stype
+        if isinstance(stype, str):
+            self._assign_scatm_from_string(stype)
         else:
-            assert stype in SCATMODELS.keys()
-            self.scatm = SCATMODELS[stype]
+            assert custom  # Check that the user intended to set up a custom model
+            self.scatm = stype
 
         self.lam      = None  # NE
         self.lam_unit = None  # string
@@ -48,6 +47,10 @@ class SingleGrainPop(graindist.GrainDist):
         self.tau_ext  = None  # NE
         self.diff     = None  # NE x NA x NTH [cm^2 / arcsec^2]
         self.int_diff = None  # NE x NTH [arcsec^2], differential xsect integrated over grain size
+
+    def _assign_scatm_from_string(self, stype):
+        assert stype in SCATMODELS.keys()
+        self.scatm = SCATMODELS[stype]
 
     def calculate_ext(self, lam, unit='kev', theta=0.0, **kwargs):
         self.scatm.calculate(lam, self.a, self.comp, unit=unit, theta=theta, **kwargs)

--- a/tests/test_grainpop.py
+++ b/tests/test_grainpop.py
@@ -4,6 +4,7 @@ from scipy.integrate import trapz
 
 from newdust.grainpop import *
 from newdust import graindist
+from newdust import scatmodels
 from . import percent_diff
 
 MD = 1.e-5  # g cm^-2
@@ -110,3 +111,11 @@ def test_mass_double(estring):
     assert all(percent_diff(gp2.tau_ext, 2.0 * gp1.tau_ext) <= 0.01)
     assert all(percent_diff(gp2.tau_abs, 2.0 * gp1.tau_abs) <= 0.01)
     assert all(percent_diff(gp2.tau_sca, 2.0 * gp1.tau_sca) <= 0.01)
+
+##---------- Test that we can customize the grain populations easily
+def test_custom_SingleGrainPop():
+    sdist = graindist.sizedist.Powerlaw()
+    compo = graindist.composition.CmSilicate(rho=3.0)
+    mscat = scatmodels.Mie()
+    test  = SingleGrainPop(sdist, compo, 'Mie', custom=True)
+    test  = SingleGrainPop(sdist, compo, mscat, custom=True)

--- a/tests/test_grainpop.py
+++ b/tests/test_grainpop.py
@@ -117,5 +117,5 @@ def test_custom_SingleGrainPop():
     sdist = graindist.sizedist.Powerlaw()
     compo = graindist.composition.CmSilicate(rho=3.0)
     mscat = scatmodels.Mie()
-    test  = SingleGrainPop(sdist, compo, 'Mie', custom=True)
     test  = SingleGrainPop(sdist, compo, mscat, custom=True)
+    test  = SingleGrainPop(sdist, compo, 'RG', custom=True)


### PR DESCRIPTION
By running `SingleGrainPop(..., custom=True)` one can use SizeDist, Composition, and ScatModel objects as input.

If the `scatm` argument is a string, the SingleGrainPop object will be instantiated with the corresponding ScatModel set forth in `newdust.grainpop.SCATMODELS`. However, the user *must* provide a valid Sizedist and Composition object when `custom=True`. These arguments are used to construct the underlying GrainDist object.  (SingleGrainPop is a sub-class of GrainDist)