### PR TITLE
Read tables to load custom scattering model

### DIFF
--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -46,7 +46,8 @@ class SingleGrainPop(graindist.GrainDist):
         # Handling scattering model FITS input, if requested
         if scatm_from_file is not None:
             self.scatm = scatmodels.ScatModel(from_file=scatm_from_file)
-            self.scatm.stype = scatm_from_file
+            assert isinstance(stype, str)
+            self.scatm.stype = stype
             self.lam = self.scatm.pars['lam']
             self.lam_unit = self.scatm.pars['unit']
             self.calculate_ext()

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -50,7 +50,7 @@ class SingleGrainPop(graindist.GrainDist):
             self.scatm.stype = stype
             self.lam = self.scatm.pars['lam']
             self.lam_unit = self.scatm.pars['unit']
-            self.calculate_ext()
+            self._calculate_tau()
         # Otherwise choose from existing (or custom) scattering calculators
         elif isinstance(stype, str):
             self._assign_scatm_from_string(stype)
@@ -62,11 +62,15 @@ class SingleGrainPop(graindist.GrainDist):
         assert stype in SCATMODELS.keys()
         self.scatm = SCATMODELS[stype]
 
-    # Default is to calculate extinction parameters at 1 keV
-    def calculate_ext(self, lam=1.0, unit='kev', theta=0.0, **kwargs):
+    # Run scattering model calculation, then compute optical depths
+    def calculate_ext(self, lam, unit='kev', theta=0.0, **kwargs):
         self.scatm.calculate(lam, self.a, self.comp, unit=unit, theta=theta, **kwargs)
         self.lam      = lam
         self.lam_unit = unit
+        self._calculate_tau()
+
+    # Compute optical depths only
+    def _calculate_tau(self):
         NE, NA, NTH = np.shape(self.scatm.diff)
         # In single size grain case
         if len(self.a) == 1:

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -32,13 +32,8 @@ class SingleGrainPop(graindist.GrainDist):
     | write_extinction_table(outfile, **kwargs) writes extinction table
     |    (qext, qabs, qsca, and diff-xsect) for the calculated scattering properties
     """
-    def __init__(self, dtype, cmtype, stype, shape='Sphere', md=MD_DEFAULT, custom=False, **kwargs):
+    def __init__(self, dtype, cmtype, stype, shape='Sphere', md=MD_DEFAULT, custom=False, scatm_from_file=None, **kwargs):
         graindist.GrainDist.__init__(self, dtype, cmtype, shape=shape, md=md, custom=custom, **kwargs)
-        if isinstance(stype, str):
-            self._assign_scatm_from_string(stype)
-        else:
-            assert custom  # Check that the user intended to set up a custom model
-            self.scatm = stype
 
         self.lam      = None  # NE
         self.lam_unit = None  # string
@@ -48,11 +43,26 @@ class SingleGrainPop(graindist.GrainDist):
         self.diff     = None  # NE x NA x NTH [cm^2 / arcsec^2]
         self.int_diff = None  # NE x NTH [arcsec^2], differential xsect integrated over grain size
 
+        # Handling scattering model FITS input, if requested
+        if scatm_from_file is not None:
+            self.scatm = scatmodels.ScatModel(from_file=scatm_from_file)
+            self.scatm.stype = scatm_from_file
+            self.lam = self.scatm.pars['lam']
+            self.lam_unit = self.scatm.pars['unit']
+            self.calculate_ext()
+        # Otherwise choose from existing (or custom) scattering calculators
+        elif isinstance(stype, str):
+            self._assign_scatm_from_string(stype)
+        else:
+            assert custom  # Check that the user intended to set up a custom model
+            self.scatm = stype
+
     def _assign_scatm_from_string(self, stype):
         assert stype in SCATMODELS.keys()
         self.scatm = SCATMODELS[stype]
 
-    def calculate_ext(self, lam, unit='kev', theta=0.0, **kwargs):
+    # Default is to calculate extinction parameters at 1 keV
+    def calculate_ext(self, lam=1.0, unit='kev', theta=0.0, **kwargs):
         self.scatm.calculate(lam, self.a, self.comp, unit=unit, theta=theta, **kwargs)
         self.lam      = lam
         self.lam_unit = unit

--- a/newdust/scatmodels/__init__.py
+++ b/newdust/scatmodels/__init__.py
@@ -1,5 +1,6 @@
 from .rgscat import RGscat
 from .miescat import Mie
+from .scatmodel import ScatModel
 from .. import constants as c
 
 """

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -40,23 +40,12 @@ class Mie(ScatModel):
     |    limits size of complex number array used in Mie scattering calculation
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        ScatModel.__init__(self, **kwargs)
         self.stype = 'Mie'
         self.citation = 'Mie scattering algorithm from Bohren & HOffman\n*Absorption and Scattering of Light by Small Particles*'
-        self.pars  = None  # parameters used in running the calculation: lam, a, cm, theta, unit
-        self.qsca  = None
-        self.qext  = None
-        self.diff  = None
         self.gsca  = None
         self.qback = None
-
-    @property
-    def qabs(self):
-        if self.qext is None:
-            print("Error: Need to calculate cross sections")
-            return 0.0
-        else:
-            return self.qext - self.qsca
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0, memlim=MAX_RAM):
 
@@ -89,6 +78,7 @@ class Mie(ScatModel):
 
         self.qsca  = qsca  # NE x NA
         self.qext  = qext
+        self.qabs  = self.qext - self.qext
         self.qback = qback
         self.gsca  = gsca
         self.diff  = Cdiff * geo_3d  # cm^2 / ster,  NE x NA x NTH

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -78,7 +78,7 @@ class Mie(ScatModel):
 
         self.qsca  = qsca  # NE x NA
         self.qext  = qext
-        self.qabs  = self.qext - self.qext
+        self.qabs  = self.qext - self.qsca
         self.qback = qback
         self.gsca  = gsca
         self.diff  = Cdiff * geo_3d  # cm^2 / ster,  NE x NA x NTH

--- a/newdust/scatmodels/rgscat.py
+++ b/newdust/scatmodels/rgscat.py
@@ -63,7 +63,7 @@ class RGscat(ScatModel):
         qsca = _qsca(x, mm1)
         self.qsca = qsca
         self.qext = qsca
-        self.qabs = self.qext - self.qext
+        self.qabs = self.qext - self.qsca
 
         # Make the NE x NA x NTH stuff
         dsig        = _dsig(a_cm, x, mm1)

--- a/newdust/scatmodels/rgscat.py
+++ b/newdust/scatmodels/rgscat.py
@@ -17,6 +17,7 @@ class RGscat(ScatModel):
     | citation : string : citation string
     | pars  : dict   : parameters used to run the calculation
     | qsca  : array  : scattering efficiency (unitless, per geometric area)
+    | qabs  : array  : absorption efficiency (unitless, per geometric area)
     | qext  : array  : extinction efficiency (unitless, per geometric area)
     | diff  : array  : differential scattering cross-section (cm^2 ster^-1)
     |
@@ -30,17 +31,10 @@ class RGscat(ScatModel):
     |    calculates the relevant values (qsca, qext, diff)
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
+        ScatModel.__init__(self, **kwargs)
         self.stype = 'RGscat'
         self.citation = 'Calculating RG-Drude approximation\nMauche & Gorenstein (1986), ApJ 302, 371\nSmith & Dwek (1998), ApJ, 503, 831'
-        self.pars  = None  # parameters used in running the calculation: lam, a, cm, theta, unit
-        self.qsca  = None
-        self.qext  = None
-        self.diff  = None
-
-    @property
-    def qabs(self):
-        return self.qext - self.qsca
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0):
         self.pars = dict(zip(['lam','a','cm','theta','unit'],[lam, a, cm, theta, unit]))
@@ -69,6 +63,7 @@ class RGscat(ScatModel):
         qsca = _qsca(x, mm1)
         self.qsca = qsca
         self.qext = qsca
+        self.qabs = self.qext - self.qext
 
         # Make the NE x NA x NTH stuff
         dsig        = _dsig(a_cm, x, mm1)

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -10,6 +10,7 @@ class ScatModel(object):
         self.qabs = None
         self.diff = None
         self.pars = None
+        #self.read_from_table(from_table)
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0, **kwargs):
         print("You are attempting to run calculation from ScatModel superclass.")

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -15,8 +15,8 @@ class ScatModel(object):
             self.read_from_table(from_file)
             self.stype = from_file
 
-    # Base superclass does nothing
-    def calculate(self, *args, **kwargs):
+    # Base calculate method does nothing
+    def calculate(self, lam, a, cm, **kwargs):
         return
 
     def write_table(self, outfile, overwrite=True):

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -35,6 +35,22 @@ class ScatModel(object):
         hdu_list.writeto(outfile, overwrite=overwrite)
         return
 
+    def read_from_table(self, infile):
+        ff = fits.open(infile)
+        # Load parameteric information
+        lam   = ff[1].data['lam']
+        unit  = ff[1].data['lam'].unit
+        a     = ff[2].data['a']
+        theta = ff[3].data['theta']
+        self.pars = {'lam':lam, 'a':a, 'unit':unit, 'theta':theta}
+
+        # Load extinction information
+        qtypes = {'Qext':self.qext, 'Qabs':self.qabs, 'Qsca':self.qsca, 'Diff-xsect (cm^2/ster)':self.diff}
+        for i in range(4,8):  # runs on hdus 4,5,6,7
+            htype = ff[i].header['TYPE']
+            qtypes[htype] = ff[i].data
+        return
+
     ##----- Helper material
     def _write_table_header(self):
         """ Writes FITS file header based on self.pars """

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -13,14 +13,19 @@ class ScatModel(object):
         if from_file is not None:
             self.read_from_table(from_file)
 
-    def calculate(self, lam, a, cm, unit='kev', theta=0.0, **kwargs):
-        print("You are attempting to run calculation from ScatModel superclass.")
-        print("No attributes will be updated.")
-        self.pars = {'lam':lam, 'a':a, 'cm':cm, 'unit':unit, 'theta':theta}
+    # Base superclass does nothing
+    def calculate(self, *args, **kwargs):
         return
 
     def write_table(self, outfile, overwrite=True):
-        # some basic info
+        # Don't write a table that has not been calculated
+        try:
+            assert self.pars is not None
+        except:
+            print("There are no values to store.")
+            return
+        
+        # All must be well! Store information in a FITS file
         header    = self._write_table_header()
         # wavelength (or energy) and grain radius associated with calculation
         par_table = self._write_table_pars()

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -10,8 +10,10 @@ class ScatModel(object):
         self.qabs = None
         self.diff = None
         self.pars = None
+        self.stype = 'Empty'
         if from_file is not None:
             self.read_from_table(from_file)
+            self.stype = from_file
 
     # Base superclass does nothing
     def calculate(self, *args, **kwargs):

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -30,7 +30,7 @@ class ScatModel(object):
                           ['Qext', 'Qabs', 'Qsca', 'Diff-xsect (cm^2/ster)']):
             htemp = fits.Header()
             htemp['TYPE'] = h
-            img_list.append(fits.ImageHDU(self.qext, header=htemp))
+            img_list.append(fits.ImageHDU(q, header=htemp))
         # Put everything together to write the table
         fnl_list  = [header] + par_table + img_list
         hdu_list  = fits.HDUList(hdus=fnl_list)
@@ -47,10 +47,14 @@ class ScatModel(object):
         self.pars = {'lam':lam, 'a':a, 'unit':unit, 'theta':theta}
 
         # Load extinction information
-        qtypes = {'Qext':self.qext, 'Qabs':self.qabs, 'Qsca':self.qsca, 'Diff-xsect (cm^2/ster)':self.diff}
+        qvals = dict()
         for i in range(4,8):  # runs on hdus 4,5,6,7
             htype = ff[i].header['TYPE']
-            qtypes[htype] = ff[i].data
+            qvals[htype] = ff[i].data
+        self.qext = qvals['Qext']
+        self.qabs = qvals['Qabs']
+        self.qsca = qvals['Qsca']
+        self.diff = qvals['Diff-xsect (cm^2/ster)']
         return
 
     ##----- Helper material

--- a/newdust/scatmodels/scatmodel.py
+++ b/newdust/scatmodels/scatmodel.py
@@ -4,13 +4,14 @@ from .. import constants as c
 ## Superclass _ScatModel
 ## See __init__ for API
 class ScatModel(object):
-    def __init__(self):
+    def __init__(self, from_file=None):
         self.qsca = None
         self.qext = None
         self.qabs = None
         self.diff = None
         self.pars = None
-        #self.read_from_table(from_table)
+        if from_file is not None:
+            self.read_from_table(from_file)
 
     def calculate(self, lam, a, cm, unit='kev', theta=0.0, **kwargs):
         print("You are attempting to run calculation from ScatModel superclass.")
@@ -40,7 +41,7 @@ class ScatModel(object):
         ff = fits.open(infile)
         # Load parameteric information
         lam   = ff[1].data['lam']
-        unit  = ff[1].data['lam'].unit
+        unit  = ff[1].data.columns['lam'].unit
         a     = ff[2].data['a']
         theta = ff[3].data['theta']
         self.pars = {'lam':lam, 'a':a, 'unit':unit, 'theta':theta}

--- a/tests/test_grainpop.py
+++ b/tests/test_grainpop.py
@@ -98,7 +98,14 @@ def test_ext_calculations(sd, cm, sc):
     assert np.shape(test.diff) == (NE, len(test.a), NTH)
     assert all(percent_diff(test.tau_ext, test.tau_abs + test.tau_sca) <= 0.01)
     test.info()
+    # Test write and read functions
     test.write_extinction_table('test_grainpop.fits')
+    new_test = SingleGrainPop(sd, cm, sc, scatm_from_file='test_grainpop.fits')
+    assert all(percent_diff(test.tau_ext, new_test.tau_ext) <= 1.e-5)
+    assert all(percent_diff(test.tau_abs, new_test.tau_abs) <= 1.e-5)
+    assert all(percent_diff(test.tau_sca, new_test.tau_sca) <= 1.e-5)
+    assert all(percent_diff(test.diff, new_test.diff) <= 1.e-5)
+    assert all(percent_diff(test.int_diff, new_test.int_diff) <= 1.e-5)
 
 # Make sure that doubling the dust mass doubles the extinction
 @pytest.mark.parametrize('estring', ALLOWED_SCATM)

--- a/tests/test_grainpop.py
+++ b/tests/test_grainpop.py
@@ -104,8 +104,8 @@ def test_ext_calculations(sd, cm, sc):
     assert all(percent_diff(test.tau_ext, new_test.tau_ext) <= 1.e-5)
     assert all(percent_diff(test.tau_abs, new_test.tau_abs) <= 1.e-5)
     assert all(percent_diff(test.tau_sca, new_test.tau_sca) <= 1.e-5)
-    assert all(percent_diff(test.diff, new_test.diff) <= 1.e-5)
-    assert all(percent_diff(test.int_diff, new_test.int_diff) <= 1.e-5)
+    assert all(percent_diff(test.diff.flatten(), new_test.diff.flatten()) <= 1.e-5)
+    assert all(percent_diff(test.int_diff.flatten(), new_test.int_diff.flatten()) <= 1.e-5)
 
 # Make sure that doubling the dust mass doubles the extinction
 @pytest.mark.parametrize('estring', ALLOWED_SCATM)

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -59,6 +59,9 @@ def test_rgscat():
     test.calculate(E_KEV, A_UM, CMD, unit='kev', theta=1.e10)
     assert test.diff == 0.0
 
+    # Test that the extinction values are correct
+    assert percent_diff(test.qext, test.qabs + test.qsca) <= 0.01
+    
     # Test the write function
     test.write_table('qrg.fits')
     # Test the read function
@@ -86,6 +89,9 @@ def test_mie(cm):
     dtot = trapz(test.diff * 2.0*np.pi*np.sin(THETA), THETA)  # cm^2
     sigsca = test.qsca * np.pi * (A_UM * c.micron2cm)**2  # cm^2
     assert percent_diff(dtot, sigsca) <= 0.01
+
+    # Test that the extinction values are correct
+    assert percent_diff(test.qext, test.qabs + test.qsca) <= 0.01
 
     # Test the write function
     test.write_table('qmie.fits')

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -89,6 +89,7 @@ def test_mie(cm):
 
     # Test the write function
     test.write_table('qmie.fits')
+    # Test the read function
     new_test = scatmodels.ScatModel(from_file='qmie.fits')
     assert percent_diff(test.qext, new_test.qext) <= 1.e-5
     assert percent_diff(test.qabs, new_test.qabs) <= 1.e-5

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -115,12 +115,3 @@ def test_dimensions(sm):
     assert percent_diff(dtot1, ssca1) <= 0.05
     assert percent_diff(dtot2, ssca2) <= 0.05
 
-from newdust.scatmodels.scatmodel import ScatModel
-# Test the writing and reading functions
-@pytest.mark.parametrize('sm', [ScatModel()])
-#                         [scatmodels.RGscat(),
-#                          scatmodels.Mie()])
-def test_writing(sm):
-    sm.calculate(0.0, 0.0, 0.0)
-    sm.write_table('test_scatmodels.fits')
-    test = ScatModel(from_file='test_scatmodels.fits')

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -61,6 +61,8 @@ def test_rgscat():
 
     # Test the write function
     test.write_table('qrg.fits')
+    # Test the read function
+    new_test = scatmodels.ScatModel(from_file='qrg.fits')
 
 @pytest.mark.parametrize('cm',
                          [composition.CmDrude(),
@@ -84,6 +86,9 @@ def test_mie(cm):
 
     # Test the write function
     test.write_table('qmie.fits')
+    # Test the read function
+    new_test = scatmodels.ScatModel(from_file='qmie.fits')
+
 
 @pytest.mark.parametrize('sm',
                          [scatmodels.RGscat(),
@@ -113,3 +118,4 @@ from newdust.scatmodels.scatmodel import ScatModel
 def test_writing(sm):
     sm.calculate(0.0, 0.0, 0.0)
     sm.write_table('test_scatmodels.fits')
+    test = ScatModel(from_file='test_scatmodels.fits')

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -63,7 +63,10 @@ def test_rgscat():
     test.write_table('qrg.fits')
     # Test the read function
     new_test = scatmodels.ScatModel(from_file='qrg.fits')
-
+    assert percent_diff(test.qext, new_test.qext) <= 1.e-5
+    assert percent_diff(test.qabs, new_test.qabs) <= 1.e-5
+    assert percent_diff(test.qsca, new_test.qsca) <= 1.e-5
+    
 @pytest.mark.parametrize('cm',
                          [composition.CmDrude(),
                           composition.CmSilicate(),
@@ -86,9 +89,10 @@ def test_mie(cm):
 
     # Test the write function
     test.write_table('qmie.fits')
-    # Test the read function
     new_test = scatmodels.ScatModel(from_file='qmie.fits')
-
+    assert percent_diff(test.qext, new_test.qext) <= 1.e-5
+    assert percent_diff(test.qabs, new_test.qabs) <= 1.e-5
+    assert percent_diff(test.qsca, new_test.qsca) <= 1.e-5
 
 @pytest.mark.parametrize('sm',
                          [scatmodels.RGscat(),


### PR DESCRIPTION
Can load FITS tables into a ScatModel object or a SingleGrainPop

For example:

```
from newdust.scatmodels import ScatModel
my_sil = ScatModel(from_file='sil_table.fits')
```

```
from newdust import SingleGrainPop
my_pop = SingleGrainPop('Powerlaw', 'Silicate', 'MyCustomSil', scatm_from_file='sil_table.fits'
```