### PR TITLE
Added a read and write functionality to Halo object

### DIFF
--- a/newdust/halos/halo.py
+++ b/newdust/halos/halo.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.integrate import trapz
+from astropy.io import fits
+from .. import constants as c
 
 __all__ = ['Halo']
 
@@ -144,11 +146,11 @@ class Halo(object):
         hdr = fits.Header()
         hdr['COMMENT'] = "Normalized halo intensity as a function of angle"
         hdr['COMMENT'] = "HDU 1 is ENERGY, HDU 2 is THETA, HDU 3 is TAUX"
-        primary_hdu = fits.PrimaryHDU(self.norm_int, header=result)
+        primary_hdu = fits.PrimaryHDU(self.norm_int, header=hdr)
 
-        hdus_to_write = primary_hdu + self._write_halo_pars()
+        hdus_to_write = [primary_hdu] + self._write_halo_pars()
         hdu_list = fits.HDUList(hdus=hdus_to_write)
-        hdu_list.writeto(outfile, overwrite=overwrite)
+        hdu_list.writeto(filename, overwrite=overwrite)
         return
 
     ##----- Helper material
@@ -158,7 +160,7 @@ class Halo(object):
         # should this be part of WCS?
         c1 = fits.BinTableHDU.from_columns(
              [fits.Column(name='lam', array=c._make_array(self.lam),
-             format='E', unit=self.lam_unit])
+             format='E', unit=self.lam_unit)])
         c2 = fits.BinTableHDU.from_columns(
              [fits.Column(name='theta', array=c._make_array(self.theta),
              format='E', unit='arcsec')])

--- a/newdust/halos/halo.py
+++ b/newdust/halos/halo.py
@@ -130,3 +130,39 @@ class Halo(object):
         fh_tot   = np.sum(self.fhalo)
         enclosed = trapz(I_grid * 2.0 * np.pi * th_grid, th_grid)
         return enclosed / fh_tot
+
+    def write(self, filename, overwrite=True):
+        """
+        Inputs
+        ------
+        filename : string
+            Name for the output FITS file
+
+        Write the scattering halo 'norm_int' attribute to a FITS file.
+        The file will also store the relevant LAM, THETA, and TAUX values.
+        """
+        hdr = fits.Header()
+        hdr['COMMENT'] = "Normalized halo intensity as a function of angle"
+        hdr['COMMENT'] = "HDU 1 is ENERGY, HDU 2 is THETA, HDU 3 is TAUX"
+        primary_hdu = fits.PrimaryHDU(self.norm_int, header=result)
+
+        hdus_to_write = primary_hdu + self._write_halo_pars()
+        hdu_list = fits.HDUList(hdus=hdus_to_write)
+        hdu_list.writeto(outfile, overwrite=overwrite)
+        return
+
+    ##----- Helper material
+    def _write_halo_pars(self):
+        """Write the FITS file"""
+        # e.g. pars['lam'], pars['a']
+        # should this be part of WCS?
+        c1 = fits.BinTableHDU.from_columns(
+             [fits.Column(name='lam', array=c._make_array(self.lam),
+             format='E', unit=self.lam_unit])
+        c2 = fits.BinTableHDU.from_columns(
+             [fits.Column(name='theta', array=c._make_array(self.theta),
+             format='E', unit='arcsec')])
+        c3 = fits.BinTableHDU.from_columns(
+             [fits.Column(name='taux', array=c._make_array(self.taux),
+             format='E', unit='')])
+        return [c1, c2, c3]

--- a/newdust/halos/halo.py
+++ b/newdust/halos/halo.py
@@ -34,7 +34,7 @@ class Halo(object):
     | ecf(th, n)
     | __getitem__(lmin, lmax)
     """
-    def __init__(self, lam, theta, unit='kev'):
+    def __init__(self, lam=1.0, theta=1.0, unit='kev', from_file=None, **kwargs):
         self.lam       = lam    # length NE
         self.lam_unit  = unit   # 'kev' or 'angs'
         self.theta     = theta  # length NTH, arcsec
@@ -44,6 +44,8 @@ class Halo(object):
         self.fabs      = None   # NE, bin integrated flux [e.g. phot/cm^2/s, NOT phot/cm^2/s/keV]
         self.funit     = None
         self.intensity = None   # NTH, flux x arcsec^-2
+        if from_file is not None:
+            self._read_from_file(from_file, **kwargs)
 
     def calculate_intensity(self, flux, ftype='abs', funit='none'):
         assert self.norm_int is not None
@@ -145,7 +147,7 @@ class Halo(object):
         """
         hdr = fits.Header()
         hdr['COMMENT'] = "Normalized halo intensity as a function of angle"
-        hdr['COMMENT'] = "HDU 1 is ENERGY, HDU 2 is THETA, HDU 3 is TAUX"
+        hdr['COMMENT'] = "HDU 1 is LAM, HDU 2 is THETA, HDU 3 is TAUX"
         primary_hdu = fits.PrimaryHDU(self.norm_int, header=hdr)
 
         hdus_to_write = [primary_hdu] + self._write_halo_pars()
@@ -168,3 +170,16 @@ class Halo(object):
              [fits.Column(name='taux', array=c._make_array(self.taux),
              format='E', unit='')])
         return [c1, c2, c3]
+
+    def _read_from_file(self, filename, htype='CustomFile'):
+        """Read a Halo object from a FITS file"""
+        ff = fits.open(filename)
+        # Load the normalized intensity
+        self.norm_int = ff[0].data
+        # Load the other parameters
+        self.lam = ff[1].data['lam']
+        self.lam_unit = ff[1].columns['lam'].unit
+        self.theta = ff[2].data['theta']
+        self.taux = ff[3].data['taux']
+        # Set halo type
+        self.htype = htype

--- a/tests/test_galhalo.py
+++ b/tests/test_galhalo.py
@@ -112,3 +112,14 @@ def test_halo_index(test):
     assert tt.taux == test.taux[i]
     assert np.shape(tt.norm_int) == (1, NTH)
     assert np.shape(tt.intensity) == (NTH,)
+
+@pytest.mark.parametrize('test', [UNI_HALO, SCR_HALO])
+def test_halo_io(test):
+    test.write('test_halo_io.fits')
+    new_halo = Halo(from_file='test_halo_io.fits', htype=test.htype)
+    assert np.all(percent_diff(new_halo.lam,test.lam) < 0.01)
+    assert np.all(percent_diff(new_halo.theta,test.theta) < 0.01)
+    assert np.all(percent_diff(new_halo.taux,test.taux) < 0.01)
+    assert np.all(percent_diff(new_halo.norm_int.flatten(),test.norm_int.flatten()) < 0.01)
+    assert new_halo.lam_unit == test.lam_unit
+    assert np.all(new_halo.htype.md == test.htype.md)


### PR DESCRIPTION
Can now write a Halo object to a fits file:

## To write
```
from newdust.halos import Halo
from newdust.halos.galhalo import uniformISM
from newdust.grainpop import make_MRN_drude

my_halo = Halo(lam=np.linspace(1,10,20), theta=np.logspace(0, 3, 100))
gpop = make_MRN_drude(md=MD)['RGD']
uniformISM(my_halo, gpop)

my_halo.write('my_halo.fits')
```

## To read
```
loaded_halo = Halo(from_file='my_halo.fits', htype='My loaded halo')
```