### PR TITLE
Differential scattering cross-sections use ster^-1 as standard

### DIFF
--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -38,7 +38,7 @@ class SingleGrainPop(graindist.GrainDist):
         self.tau_sca  = None  # NE
         self.tau_abs  = None  # NE
         self.tau_ext  = None  # NE
-        self.diff     = None  # NE x NA x NTH [cm^2 / arcsec^2]
+        self.diff     = None  # NE x NA x NTH [cm^2 ster^-1]
         self.int_diff = None  # NE x NTH [arcsec^2], differential xsect integrated over grain size
 
         # Handling scattering model FITS input, if requested
@@ -88,10 +88,10 @@ class SingleGrainPop(graindist.GrainDist):
         # NE x NA x NTH
         area_2d = np.repeat(self.cgeo.reshape(1, NA), NE, axis=0) # cm^2
         area_3d = np.repeat(area_2d.reshape(NE, NA, 1), NTH, axis=2)
-        self.diff     = self.scatm.diff * area_3d * c.arcs2rad**2  # NE x NA x NTH, [cm^2 arcsec^-2]
+        self.diff     = self.scatm.diff * area_3d # NE x NA x NTH, [cm^2 ster^-1]
 
         if np.size(self.a) == 1:
-            int_diff = np.sum(self.scatm.diff * self.ndens[0] * c.arcs2rad**2, axis=1)
+            int_diff = np.sum(self.scatm.diff * self.cgeo[0] * self.ndens[0] * c.arcs2rad**2, axis=1)
         else:
             agrid        = np.repeat(
                 np.repeat(self.a.reshape(1, NA, 1), NE, axis=0),
@@ -99,7 +99,7 @@ class SingleGrainPop(graindist.GrainDist):
             ndgrid       = np.repeat(
                 np.repeat(self.ndens.reshape(1, NA, 1), NE, axis=0),
                 NTH, axis=2)
-            int_diff = trapz(self.scatm.diff * ndgrid, agrid, axis=1) * c.arcs2rad**2
+            int_diff = trapz(self.scatm.diff * area_3d * ndgrid, agrid, axis=1) * c.arcs2rad**2
 
         self.int_diff = int_diff  # NE x NTH, [arcsec^-2]
 

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -39,7 +39,7 @@ class SingleGrainPop(graindist.GrainDist):
         self.tau_abs  = None  # NE
         self.tau_ext  = None  # NE
         self.diff     = None  # NE x NA x NTH [cm^2 ster^-1]
-        self.int_diff = None  # NE x NTH [arcsec^2], differential xsect integrated over grain size
+        self.int_diff = None  # NE x NTH [ster^-1], differential xsect integrated over grain size
 
         # Handling scattering model FITS input, if requested
         if scatm_from_file is not None:
@@ -91,7 +91,7 @@ class SingleGrainPop(graindist.GrainDist):
         self.diff     = self.scatm.diff * area_3d # NE x NA x NTH, [cm^2 ster^-1]
 
         if np.size(self.a) == 1:
-            int_diff = np.sum(self.scatm.diff * self.cgeo[0] * self.ndens[0] * c.arcs2rad**2, axis=1)
+            int_diff = np.sum(self.scatm.diff * self.cgeo[0] * self.ndens[0], axis=1)
         else:
             agrid        = np.repeat(
                 np.repeat(self.a.reshape(1, NA, 1), NE, axis=0),
@@ -99,9 +99,9 @@ class SingleGrainPop(graindist.GrainDist):
             ndgrid       = np.repeat(
                 np.repeat(self.ndens.reshape(1, NA, 1), NE, axis=0),
                 NTH, axis=2)
-            int_diff = trapz(self.scatm.diff * area_3d * ndgrid, agrid, axis=1) * c.arcs2rad**2
+            int_diff = trapz(self.scatm.diff * area_3d * ndgrid, agrid, axis=1)
 
-        self.int_diff = int_diff  # NE x NTH, [arcsec^-2]
+        self.int_diff = int_diff  # NE x NTH, [ster^-1]
 
     # Plotting things
     def plot_sdist(self, ax, **kwargs):

--- a/newdust/grainpop.py
+++ b/newdust/grainpop.py
@@ -86,7 +86,9 @@ class SingleGrainPop(graindist.GrainDist):
             self.tau_abs = trapz(geo_2d * self.scatm.qabs, self.a, axis=1)
 
         # NE x NA x NTH
-        self.diff     = self.scatm.diff * c.arcs2rad**2  # NE x NA x NTH, [cm^2 arcsec^-2]
+        area_2d = np.repeat(self.cgeo.reshape(1, NA), NE, axis=0) # cm^2
+        area_3d = np.repeat(area_2d.reshape(NE, NA, 1), NTH, axis=2)
+        self.diff     = self.scatm.diff * area_3d * c.arcs2rad**2  # NE x NA x NTH, [cm^2 arcsec^-2]
 
         if np.size(self.a) == 1:
             int_diff = np.sum(self.scatm.diff * self.ndens[0] * c.arcs2rad**2, axis=1)

--- a/newdust/halos/galhalo.py
+++ b/newdust/halos/galhalo.py
@@ -54,10 +54,7 @@ class UniformGalHalo(Halo):
         for al in self.theta:
             thscat = al / xgrid  # nx, goes from small to large angle
             gpop.calculate_ext(self.lam, unit=self.lam_unit, theta=thscat)
-            area = gpop.shape.cgeo(gpop.a) # cm^2
-            area_2d  = np.repeat(area.reshape(1,NA), NE, axis=1)
-            area_3d  = np.repeat(area_2d.reshape(NE, NA, 1), nx, axis=2)
-            dsig   = gpop.diff * area_3d # NE x NA x nx, [cm^2 arcsec^-2]
+            dsig   = gpop.diff * c.arcs2rad**2 # NE x NA x nx, [cm^2 arcsec^-2]
             itemp  = dsig * ndmesh / xmesh**2  # NE x NA x nx, [um^-1 arcsec^-2]
 
             intx      = trapz(itemp, xgrid, axis=2)  # NE x NA, [um^-1 arcsec^-2]
@@ -99,10 +96,7 @@ class ScreenGalHalo(Halo):
 
         thscat = self.theta / x
         gpop.calculate_ext(self.lam, unit=self.lam_unit, theta=thscat)
-        area = gpop.shape.cgeo(gpop.a) # cm^2
-        area_2d  = np.repeat(area.reshape(1,NA), NE, axis=1)
-        area_3d  = np.repeat(area_2d.reshape(NE, NA, 1), NTH, axis=2)
-        dsig   = gpop.diff * area_3d # NE x NA x NTH, [cm^2 arcsec^-2]
+        dsig   = gpop.diff * c.arcs2rad**2 # NE x NA x NTH, [cm^2 arcsec^-2]
 
         ndmesh = np.repeat(
             np.repeat(gpop.ndens.reshape(1, NA, 1), NE, axis=0),

--- a/newdust/halos/galhalo.py
+++ b/newdust/halos/galhalo.py
@@ -55,7 +55,8 @@ class UniformGalHalo(Halo):
             thscat = al / xgrid  # nx, goes from small to large angle
             gpop.calculate_ext(self.lam, unit=self.lam_unit, theta=thscat)
             area = gpop.shape.cgeo(gpop.a) # cm^2
-            area_3d  = np.repeat(area.reshape(NE, NA, 1), len(x), axis=2)
+            area_2d  = np.repeat(area.reshape(1,NA), NE, axis=1)
+            area_3d  = np.repeat(area_2d.reshape(NE, NA, 1), nx, axis=2)
             dsig   = gpop.diff * area_3d # NE x NA x nx, [cm^2 arcsec^-2]
             itemp  = dsig * ndmesh / xmesh**2  # NE x NA x nx, [um^-1 arcsec^-2]
 
@@ -99,7 +100,8 @@ class ScreenGalHalo(Halo):
         thscat = self.theta / x
         gpop.calculate_ext(self.lam, unit=self.lam_unit, theta=thscat)
         area = gpop.shape.cgeo(gpop.a) # cm^2
-        area_3d  = np.repeat(area.reshape(NE, NA, 1), NTH, axis=2)
+        area_2d  = np.repeat(area.reshape(1,NA), NE, axis=1)
+        area_3d  = np.repeat(area_2d.reshape(NE, NA, 1), NTH, axis=2)
         dsig   = gpop.diff * area_3d # NE x NA x NTH, [cm^2 arcsec^-2]
 
         ndmesh = np.repeat(

--- a/newdust/halos/galhalo.py
+++ b/newdust/halos/galhalo.py
@@ -11,7 +11,7 @@ from .. import constants as c
 
 __all__ = ['UniformGalHalo','ScreenGalHalo','path_diff','time_delay']
 
-ANGLES = np.logspace(0.0, 3.5, np.int(3.5/0.05))
+ANGLES = np.logspace(0.0, 3.5, int(3.5/0.05))
 
 class UniformGalHalo(Halo):
     def __init__(self, *args, **kwargs):

--- a/newdust/halos/galhalo.py
+++ b/newdust/halos/galhalo.py
@@ -54,7 +54,9 @@ class UniformGalHalo(Halo):
         for al in self.theta:
             thscat = al / xgrid  # nx, goes from small to large angle
             gpop.calculate_ext(self.lam, unit=self.lam_unit, theta=thscat)
-            dsig   = gpop.diff  # NE x NA x nx, [cm^2 arcsec^-2]
+            area = gpop.shape.cgeo(gpop.a) # cm^2
+            area_3d  = np.repeat(area.reshape(NE, NA, 1), len(x), axis=2)
+            dsig   = gpop.diff * area_3d # NE x NA x nx, [cm^2 arcsec^-2]
             itemp  = dsig * ndmesh / xmesh**2  # NE x NA x nx, [um^-1 arcsec^-2]
 
             intx      = trapz(itemp, xgrid, axis=2)  # NE x NA, [um^-1 arcsec^-2]
@@ -96,7 +98,9 @@ class ScreenGalHalo(Halo):
 
         thscat = self.theta / x
         gpop.calculate_ext(self.lam, unit=self.lam_unit, theta=thscat)
-        dsig   = gpop.diff  # NE x NA x NTH, [cm^2 arsec^-2]
+        area = gpop.shape.cgeo(gpop.a) # cm^2
+        area_3d  = np.repeat(area.reshape(NE, NA, 1), NTH, axis=2)
+        dsig   = gpop.diff * area_3d # NE x NA x NTH, [cm^2 arcsec^-2]
 
         ndmesh = np.repeat(
             np.repeat(gpop.ndens.reshape(1, NA, 1), NE, axis=0),

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -174,7 +174,7 @@ def _mie_helper(x, refrel, theta, memlim=MAX_RAM):
 
     p    = -1.0
 
-    for n in range(1,np.int(np.max(nstop))+1):  # for n=1, nstop do begin
+    for n in range(1,int(np.max(nstop))+1):  # for n=1, nstop do begin
         assert isinstance(n, int)
         en = n
         fn = (2.0*en+1.0) / (en * (en+1.0))

--- a/newdust/scatmodels/miescat.py
+++ b/newdust/scatmodels/miescat.py
@@ -28,7 +28,7 @@ class Mie(ScatModel):
     | qext  : array  : extinction efficiency (unitless, per geometric area)
     | qback : array  : back scattering efficiency (unitless, per geometric area)
     | gsca  : array  : average scattering angle
-    | diff  : array  : differential scattering cross-section (cm^2 ster^-1)
+    | diff  : array  : differential scattering cross-section (ster^-1)
     |
     | *properties*
     | qabs  : array  : absorption efficiency (unitless, per geometric area)
@@ -72,16 +72,12 @@ class Mie(ScatModel):
 
         qsca, qext, qback, gsca, Cdiff = _mie_helper(x, refrel, theta=th_1d, memlim=memlim)
 
-        # Assumes spherical grains (implicit in Mie)
-        geo    = np.pi * a_cm**2  # NE x NA
-        geo_3d = np.repeat(geo.reshape(NE, NA, 1), NTH, axis=2)
-
         self.qsca  = qsca  # NE x NA
         self.qext  = qext
         self.qabs  = self.qext - self.qsca
         self.qback = qback
         self.gsca  = gsca
-        self.diff  = Cdiff * geo_3d  # cm^2 / ster,  NE x NA x NTH
+        self.diff  = Cdiff # ster^-1,  NE x NA x NTH
 
 #---------------- Helper function that does the actual calculation
 

--- a/newdust/scatmodels/rgscat.py
+++ b/newdust/scatmodels/rgscat.py
@@ -19,7 +19,7 @@ class RGscat(ScatModel):
     | qsca  : array  : scattering efficiency (unitless, per geometric area)
     | qabs  : array  : absorption efficiency (unitless, per geometric area)
     | qext  : array  : extinction efficiency (unitless, per geometric area)
-    | diff  : array  : differential scattering cross-section (cm^2 ster^-1)
+    | diff  : array  : differential scattering cross-section (ster^-1)
     |
     | *properties*
     | qabs  : array  : absorption efficiency (unitless, per geometric area)
@@ -75,7 +75,11 @@ class RGscat(ScatModel):
         char_3d   = np.repeat(char.reshape(NE, NA, 1), NTH, axis=2)
         thdep     = _thdep(theta_3d, char_3d)
 
-        self.diff = dsig_3d * thdep  # cm^2 / ster
+        # Divide by geometric area cross-section, assumes spherical grains
+        geo    = np.pi * a_cm**2  # NE x NA
+        geo_3d = np.repeat(geo.reshape(NE, NA, 1), NTH, axis=2)
+        
+        self.diff = dsig_3d * thdep / geo_3d  # ster^-1
 
     # Standard deviation on scattering angle distribution
     def char(self, lam, a, unit='kev'):

--- a/tests/test_galhalo.py
+++ b/tests/test_galhalo.py
@@ -5,6 +5,7 @@ from scipy.integrate import trapz
 from newdust.halos import *
 from newdust import grainpop
 from . import percent_diff
+import newdust.constants as c
 
 NE, NTH = 10, 200
 EVALS   = np.logspace(-1, 1, NE)   # keV
@@ -36,7 +37,8 @@ def test_galhalo_screen(x):
     # Observed angle should be equal to scattering angle when x = 1,
     # so halo should match differential scattering cross section integrated over dust grain size distributions
     if x == 1.0:
-        test = np.abs(SCR_HALO.norm_int - GPOP.int_diff)
+        # have to convert int_diff to arcsec^-2
+        test = np.abs(SCR_HALO.norm_int - GPOP.int_diff * c.arcs2rad**2)
         assert np.all(test < 0.01)
 
 @pytest.mark.parametrize('test', [UNI_HALO, SCR_HALO])

--- a/tests/test_grainpop.py
+++ b/tests/test_grainpop.py
@@ -106,6 +106,16 @@ def test_ext_calculations(sd, cm, sc):
     assert all(percent_diff(test.tau_sca, new_test.tau_sca) <= 1.e-5)
     assert all(percent_diff(test.diff.flatten(), new_test.diff.flatten()) <= 1.e-5)
     assert all(percent_diff(test.int_diff.flatten(), new_test.int_diff.flatten()) <= 1.e-5)
+    # Test that the integrated differential cross-sections match the scattering cross sections
+    th_2d   = np.repeat(THETA.reshape(1, 1, NTH), NE, axis=0) # NE x 1 x NA
+    th_3d   = np.repeat(th_2d.reshape(NE, 1, NTH), len(test.a), axis=1) # NE x NA x NTH
+    integrated = trapz(test.diff * 2.0 * np.pi * np.sin(th_3d), THETA, axis=2) # NE x NA
+    if sd == 'Grain':
+        sigma_scat = test.scatm.qsca * test.cgeo
+    else:
+        sigma_scat = test.scatm.qsca * np.repeat(test.cgeo.reshape(1, NA), NE, axis=0) # NE x NA [cm^2]
+    assert all(percent_diff(integrated.flatten(), sigma_scat.flatten()))
+    
 
 # Make sure that doubling the dust mass doubles the extinction
 @pytest.mark.parametrize('estring', ALLOWED_SCATM)

--- a/tests/test_scatmodels.py
+++ b/tests/test_scatmodels.py
@@ -31,11 +31,10 @@ def test_rgscat():
     test.calculate(1.e-10, A_UM, CMD, unit='kev')
     assert np.exp(-test.qsca) == 0.0
 
-    # differential cross-section must sum to total cross-section
+    # differential cross-section must sum to Qsca
     test.calculate(E_KEV, A_UM, CMD, unit='kev', theta=TH_asec)
-    dtot   = trapz(test.diff * 2.0*np.pi*np.sin(THETA), THETA)  # cm^2
-    sigsca = test.qsca * np.pi * (A_UM * c.micron2cm)**2  # cm^2
-    assert percent_diff(dtot, sigsca) <= 0.05
+    dtot   = trapz(test.diff * 2.0*np.pi*np.sin(THETA), THETA)  # unitless
+    assert percent_diff(dtot, test.qsca) <= 0.05
 
     # Test that the absorption component for RG model is zero
     assert test.qsca == test.qext
@@ -84,11 +83,10 @@ def test_mie(cm):
     assert percent_diff(np.exp(test.qext), 1.0) < 0.001
     assert percent_diff(np.exp(test.qabs), 1.0) < 0.001
 
-    # Test that the differential scattering cross section integrates to total
+    # Test that the differential scattering cross section integrates to qsca
     test.calculate(LAM, A_UM, cm, unit='angs', theta=TH_asec)
-    dtot = trapz(test.diff * 2.0*np.pi*np.sin(THETA), THETA)  # cm^2
-    sigsca = test.qsca * np.pi * (A_UM * c.micron2cm)**2  # cm^2
-    assert percent_diff(dtot, sigsca) <= 0.01
+    dtot = trapz(test.diff * 2.0*np.pi*np.sin(THETA), THETA)  # unitless
+    assert percent_diff(dtot, test.qsca) <= 0.01
 
     # Test that the extinction values are correct
     assert percent_diff(test.qext, test.qabs + test.qsca) <= 0.01
@@ -113,11 +111,3 @@ def test_dimensions(sm):
     assert np.shape(sm.qext) == (NE, NA)
     assert np.shape(sm.qabs) == (NE, NA)
     assert np.shape(sm.diff) == (NE, NA, NTH)
-
-    dtot1 = trapz(sm.diff[0,0,:] * 2.0*np.pi*np.sin(THETA), THETA)
-    dtot2 = trapz(sm.diff[-1,-1,:] * 2.0*np.pi*np.sin(THETA), THETA)
-    ssca1 = sm.qsca[0,0] * np.pi * (AVALS[0] * 1.e-4)**2
-    ssca2 = sm.qsca[-1,-1] * np.pi * (AVALS[-1] * 1.e-4)**2
-    assert percent_diff(dtot1, ssca1) <= 0.05
-    assert percent_diff(dtot2, ssca2) <= 0.05
-


### PR DESCRIPTION
The differential scattering cross-section returned by scatmodels has units of ster^-1

Differential scattering cross-section returned by grainpops now has units of cm^2 ster^-1

The halo calculators adjust the differential scattering cross-sections to be in units of arcsec^-2